### PR TITLE
Add a setting that allows picking which Severity Level is attached to each linting error in the display.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,29 @@
           ".gd"
         ]
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Godot Formatter and Linter",
+      "properties": {
+        "godotFormatterAndLinter.lintSeverityLevel": {
+          "enum": [
+            "Error",
+            "Warning",
+            "Information",
+            "Hint"
+          ],
+          "enumDescriptions": [
+            "Error",
+            "Warning",
+            "Information",
+            "Hint"
+          ],
+          "default": "Error",
+          "description": "Controls at what severity level all linting errors are set."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ export function activate(context: vscode.ExtensionContext) {
         let content = doc.fileName;
         let uri = doc.uri;
         let dir = vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath || "";
+        const severityLevel = vscode.workspace.getConfiguration("godotFormatterAndLinter").get("lintSeverityLevel", "Error");
 
         if (uri.scheme === "file" && doc.languageId === 'gdscript') {
             let cmd = `gdlint ` + content + ` 2>&1`;
@@ -32,7 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
                         let line = parseInt(match[2]) - 1;
                         let message = match[3];
                         ochan.append("Error: " + filenname + ":" + line + ": " + message + "");
-                        var va = new vscode.Diagnostic(new vscode.Range(line, 0, line, 0), message, vscode.DiagnosticSeverity.Error);
+                        const va = new vscode.Diagnostic(new vscode.Range(line, 0, line, 0), message, vscode.DiagnosticSeverity[severityLevel]);
                         va.code = "gdlint";
                         diagArr.push(va);
                     }


### PR DESCRIPTION
I don't have much experience with VSCode extensions so any feedback on my work is appreciated.

I realize this extension may get merged into the godot-gdscript-toolkit at some point, but until then it works well for me and I'd like to improve it for my use and my friends.

Also, hopefully these changes will help out when it is merged as well.