### PR TITLE
Add line length & indentation config, and improve linter visualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,33 @@
             "Hint"
           ],
           "default": "Error",
-          "description": "Controls at what severity level all linting errors are set."
+          "description": "Controls at what severity level all linting errors are set.",
+          "order": 0
+        },
+        "godotFormatterAndLinter.lineLength": {
+          "type": "integer",
+          "default": 80,
+          "description": "Maximum number of characters per line for the formatter.",
+          "order": 1
+        },
+        "godotFormatterAndLinter.indentType": {
+          "enum": [
+            "Tabs",
+            "Spaces"
+          ],
+          "enumDescriptions": [
+            "Tabs",
+            "Spaces"
+          ],
+          "default": "Tabs",
+          "description": "The type of indentation for the formatter.",
+          "order": 2
+        },
+        "godotFormatterAndLinter.indentSpacesSize": {
+          "type": "integer",
+          "default": 4,
+          "markdownDescription": "Number of spaces for each level of indentation. Only active when `#godotFormatterAndLinter.indentType#` is set to `Spaces`.",
+          "order": 3
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,8 +65,12 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider('gdscript', {
         async provideDocumentFormattingEdits(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
             let content = document.getText();
+            const indentType = vscode.workspace.getConfiguration("godotFormatterAndLinter").get("indentType");
+            const indentSpacesSize = vscode.workspace.getConfiguration("godotFormatterAndLinter").get("indentSpacesSize");
+            const indentParam = (indentType === "Tabs") ? "" : `--use-spaces=${indentSpacesSize}`;
+            const lineLength = vscode.workspace.getConfiguration("godotFormatterAndLinter").get("lineLength");
             return new Promise((res, rej) => {
-                let cmd = `gdformat -`;
+                let cmd = `gdformat --line-length=${lineLength} ${indentParam} -`;
 
                 var cpo = cp.exec(cmd, (err, stdout, stderr) => {
                     //ochan.append("stdout: " + stdout);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,11 +29,11 @@ export function activate(context: vscode.ExtensionContext) {
                     matchregex.lastIndex = 0;
                     const match = matchregex.exec(line);
                     if (match) {
-                        let filenname = match[1];
-                        let line = parseInt(match[2]) - 1;
+                        let filename = match[1];
+                        let lineno = parseInt(match[2]) - 1;
                         let message = match[3];
-                        ochan.append("Error: " + filenname + ":" + line + ": " + message + "\n");
-                        const va = new vscode.Diagnostic(new vscode.Range(line, 0, line, 0), message, vscode.DiagnosticSeverity[severityLevel]);
+                        ochan.append("Error: " + filename + ":" + lineno + ": " + message + "\n");
+                        const va = new vscode.Diagnostic(new vscode.Range(lineno, 0, lineno, line.length - 1), message, vscode.DiagnosticSeverity[severityLevel]);
                         va.code = "gdlint";
                         diagArr.push(va);
                     }


### PR DESCRIPTION
Again, thanks for maintaing this config! It's been really helpful to our project. However in our experience there are two things that can be improved:

1. Add formatter configs for line length and indentation type/size;
2. Change the linter diagostic visualizing from only marking the first word to marking the whole line. For example, say we have a function with an invalid name:
```gdscript
func ____foo():
    pass
```
The current behavior of the plugin is to underline `func`, which is confusing since the real issue comes from the name `____foo`. We think that underlining the whole line instead is a better approach.

I'm not very familiar with VSCode plugin or ts in general, so any feedback or change is appreciated!